### PR TITLE
Handle api key change gracefully.

### DIFF
--- a/example-dashboards/comparison/src/components/Main.js
+++ b/example-dashboards/comparison/src/components/Main.js
@@ -16,12 +16,24 @@ export default class Main extends Component {
     queryBuilder: new Bitmovin({ apiKey: this.props.apiKey }).analytics.queries.builder,
   };
 
-  currentLicenseKey = () => localStorage.getItem('licenseKey') || this.props.licenses[0].licenseKey;
+  currentLicenseKey = () => {
+    const currentLicenseKey = localStorage.getItem('licenseKey');
+    const { licenses } = this.props;
+    const { licenseKey } = licenses.find(l => l.licenseKey === currentLicenseKey) || licenses[0];
 
-  handleLicenseChange = (event) => {
-    localStorage.setItem('licenseKey', event.currentTarget.value)
+    if (licenseKey !== currentLicenseKey) {
+      this.setLicenseKey(licenseKey);
+    }
+
+    return licenseKey;
+  }
+
+  setLicenseKey = (licenseKey) => {
+    localStorage.setItem('licenseKey', licenseKey);
     this.forceUpdate();
   }
+
+  handleLicenseChange = (event) => this.setLicenseKey(event.currentTarget.value)
 
   handleDateRangeChange = ({ fromDate, toDate }) =>
     this.setState({ fromDate, toDate });


### PR DESCRIPTION
The app broke when another API key was passed as GET parameter: The license key in local storage still belonged to the previous API key and didn't exist for the new one. Therefore the queries failed with status 404.

This fix checks if the license key from local storage is still available and updates it otherwise with the first available license key.